### PR TITLE
flume-hive-sink 支持 Flume 进程有条件退出设置:

### DIFF
--- a/flume-ng-sinks/flume-hive-sink/src/main/java/org/apache/flume/sink/hive/Config.java
+++ b/flume-ng-sinks/flume-hive-sink/src/main/java/org/apache/flume/sink/hive/Config.java
@@ -38,4 +38,5 @@ public class Config {
   public static final String SECOND = "second";
   public static final String ROUND_VALUE = "roundValue";
   public static final String SERIALIZER = "serializer";
+  public static final String EXIT_WHEN = "exitWhen";
 }


### PR DESCRIPTION
<agent>.sinks.<hive-sink>.exitWhen = <js expression>

其中 <js expression> 应该范围 bool 值。<js expression> 可以使用 header 中的设置。

例如: header 中包含 group, topic, partition, offset, timestamp。可以设置为 "+offset > 10000"，这样 flume 进程只写入 <= 10000 的 event。
这里 + 号表示把 offset 字符串转换为数值 (javascript 语法)。