### PR TITLE
HeaderJoinInterceptor

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/interceptor/HeaderJoinInterceptor.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/interceptor/HeaderJoinInterceptor.java
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flume.interceptor;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.flume.Context;
+import org.apache.flume.Event;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Interceptor class that join two or more headers to a new header of all events.
+ *
+ * Properties:<p>
+ *   joinKeys: Headers to join together.
+ *        (default is "key")<p>
+ *   
+ *   joinKeyDefaultValues: default value to keys.
+ *        (default is "NA")<p>
+ *   
+ *   joinDelimiter: join delimiter.
+ *        (default is "-")<p>
+ *        
+ *   key: Key to use in join header insertion.
+ *        (default is "key")<p>
+ *
+ *   preserveExisting: Whether to preserve an existing value for 'key'
+ *                     (default is true)<p>
+ *
+ * Sample config:<p>
+ *
+ * <code>
+ *   agent.sources.r1.channels = c1<p>
+ *   agent.sources.r1.type = SEQ<p>
+ *   agent.sources.r1.interceptors = i1<p>
+ *   agent.sources.r1.interceptors.i1.type = join<p>
+ *   agent.sources.r1.interceptors.i1.joinKeys = topic partition<p>
+ *   agent.sources.r1.interceptors.i1.joinKeyDefaultValues = NA<p>
+ *   agent.sources.r1.interceptors.i1.joinDelimiter = -<p>
+ *   agent.sources.r1.interceptors.i1.preserveExisting = false<p>
+ *   agent.sources.r1.interceptors.i1.key = datacenter<p>
+ * </code>
+ *
+ */
+public class HeaderJoinInterceptor implements Interceptor {
+
+  private static final Logger logger = LoggerFactory.getLogger(HeaderJoinInterceptor.class);
+
+  private final String[] joinKeys;
+  private final String[] joinKeyDefaultValues;
+  private final String joinDelimiter;
+  private final boolean preserveExisting;
+  private final String key;
+
+  /**
+   * Only {@link HostInterceptor.Builder} can build me
+   */
+  private HeaderJoinInterceptor(String joinKeys, String joinKeyDefaultValues,
+          String joinDelimiter, boolean preserveExisting,
+          String key) {
+    this.joinKeys = (joinKeys == null || joinKeys.isEmpty())
+      ? new String[]{ key } : joinKeys.split(" ");
+    this.joinKeyDefaultValues = joinKeyDefaultValues.split(" ");
+    this.joinDelimiter = joinDelimiter;
+    this.preserveExisting = preserveExisting;
+    this.key = key;
+  }
+
+  @Override
+  public void initialize() {
+    // no-op
+  }
+
+  /**
+   * Modifies events in-place.
+   */
+  @Override
+  public Event intercept(Event event) {
+    Map<String, String> headers = event.getHeaders();
+
+    if (preserveExisting && headers.containsKey(key)) {
+      return event;
+    }
+    
+    String[] values = new String[this.joinKeys.length];
+    for (int i = 0; i < this.joinKeys.length; ++i) {
+      values[i] = headers.getOrDefault(this.joinKeys[i],
+        this.joinKeyDefaultValues[i % this.joinKeyDefaultValues.length]);
+    }
+    headers.put(key, String.join(this.joinDelimiter, values));
+    return event;
+  }
+
+  /**
+   * Delegates to {@link #intercept(Event)} in a loop.
+   * @param events
+   * @return
+   */
+  @Override
+  public List<Event> intercept(List<Event> events) {
+    for (Event event : events) {
+      intercept(event);
+    }
+    return events;
+  }
+
+  @Override
+  public void close() {
+    // no-op
+  }
+
+  /**
+   * Builder which builds new instance of the HeaderJoinInterceptor.
+   */
+  public static class Builder implements Interceptor.Builder {
+
+    private String joinKeys;
+    private String joinKeyDefaultValues;
+    private String joinDelimiter;
+    private boolean preserveExisting;
+    private String key;
+
+    @Override
+    public void configure(Context context) {
+      joinKeys = context.getString(Constants.JOIN_KEYS, Constants.JOIN_KEYS_DEFAULT);
+      joinKeyDefaultValues = context.getString(Constants.JOIN_KEY_DEFAULT_VALUES, 
+              Constants.JOIN_KEY_DEFAULT_VALUES_DEFAULT);
+      joinDelimiter = context.getString(Constants.JOIN_DELIMITER, Constants.JOIN_DELIMITER_DEFAULT);
+      preserveExisting = context.getBoolean(Constants.PRESERVE, Constants.PRESERVE_DEFAULT);
+      key = context.getString(Constants.KEY, Constants.KEY_DEFAULT);
+    }
+
+    @Override
+    public Interceptor build() {
+      logger.info(String.format(
+          "Creating HeaderJoinInterceptor: joinKeys=%s,joinKeyDefaultValues=%s,"
+          + "joinDelimiter=%s,preserveExisting=%s,key=%s",
+          joinKeys, joinKeyDefaultValues, joinDelimiter, preserveExisting, key));
+      return new HeaderJoinInterceptor(joinKeys, joinKeyDefaultValues, joinDelimiter, 
+              preserveExisting, key);
+    }
+
+  }
+
+  public static class Constants {
+    public static final String JOIN_KEYS = "joinKeys";
+    public static final String JOIN_KEYS_DEFAULT = null;
+    
+    public static final String JOIN_KEY_DEFAULT_VALUES = "joinKeyDefaultValues";
+    public static final String JOIN_KEY_DEFAULT_VALUES_DEFAULT = "NA";
+    
+    public static final String JOIN_DELIMITER = "joinDelimiter";
+    public static final String JOIN_DELIMITER_DEFAULT = "-";
+    
+    public static final String KEY = "key";
+    public static final String KEY_DEFAULT = "key";
+
+    public static final String PRESERVE = "preserveExisting";
+    public static final boolean PRESERVE_DEFAULT = true;
+  }
+}

--- a/flume-ng-core/src/test/java/org/apache/flume/interceptor/TestHeaderJoinInterceptor.java
+++ b/flume-ng-core/src/test/java/org/apache/flume/interceptor/TestHeaderJoinInterceptor.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flume.interceptor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.flume.Context;
+import org.apache.flume.Event;
+import org.apache.flume.event.EventBuilder;
+import org.apache.flume.interceptor.HeaderJoinInterceptor.Constants;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.base.Charsets;
+
+public class TestHeaderJoinInterceptor {
+  private Interceptor.Builder builder;
+  
+  @Before
+  public void setup() throws ClassNotFoundException,
+      InstantiationException, IllegalAccessException {
+    builder = new org.apache.flume.interceptor.HeaderJoinInterceptor.Builder();
+  }
+  
+  @Test
+  public void testDefaultKeyValue() throws ClassNotFoundException,
+      InstantiationException, IllegalAccessException {
+    builder.configure(new Context());
+    Interceptor interceptor = builder.build();
+
+    Event event = EventBuilder.withBody("test", Charsets.UTF_8);
+    Assert.assertNull(event.getHeaders().get(Constants.KEY));
+
+    event = interceptor.intercept(event);
+    String val = event.getHeaders().get(Constants.KEY);
+
+    Assert.assertNotNull(val);
+    Assert.assertEquals(Constants.JOIN_KEY_DEFAULT_VALUES_DEFAULT, val);
+  }
+
+  @Test
+  public void testCustomKeyValue() throws ClassNotFoundException,
+      InstantiationException, IllegalAccessException {
+    Context ctx = new Context();
+    ctx.put(Constants.JOIN_KEYS, "topic partition");
+    ctx.put(Constants.JOIN_DELIMITER, ":");
+    ctx.put(Constants.KEY, "myKey");
+
+    builder.configure(ctx);
+    Interceptor interceptor = builder.build();
+
+    Map<String, String> headers = new HashMap<String, String>();
+    headers.put("topic", "myTopic");
+    headers.put("partition", "1");
+    
+    Event event = EventBuilder.withBody("test", Charsets.UTF_8, headers);
+    Assert.assertNull(event.getHeaders().get("myKey"));
+
+    event = interceptor.intercept(event);
+    String val = event.getHeaders().get("myKey");
+
+    Assert.assertNotNull(val);
+    Assert.assertEquals("myTopic:1", val);
+  }
+
+  @Test
+  public void testReplace() throws ClassNotFoundException,
+      InstantiationException, IllegalAccessException {
+    Context ctx = new Context();
+    ctx.put(Constants.JOIN_KEYS, "topic partition");
+    ctx.put(Constants.PRESERVE, "false");
+    ctx.put(Constants.JOIN_KEY_DEFAULT_VALUES, "replacement value");
+
+    builder.configure(ctx);
+    Interceptor interceptor = builder.build();
+
+    Event event = EventBuilder.withBody("test", Charsets.UTF_8);
+    event.getHeaders().put(Constants.KEY_DEFAULT, "incumbent+value");
+
+    Assert.assertNotNull(event.getHeaders().get(Constants.KEY_DEFAULT));
+
+    event = interceptor.intercept(event);
+    String val = event.getHeaders().get(Constants.KEY_DEFAULT);
+
+    Assert.assertNotNull(val);
+    Assert.assertEquals("replacement-value", val);
+  }
+
+  @Test
+  public void testPreserve() throws ClassNotFoundException,
+      InstantiationException, IllegalAccessException {
+    Interceptor.Builder builder = InterceptorBuilderFactory.newInstance(
+        InterceptorType.STATIC.toString());
+    Context ctx = new Context();
+    ctx.put(Constants.PRESERVE, "true");
+    ctx.put(Constants.JOIN_KEY_DEFAULT_VALUES, "replacement+value");
+
+    builder.configure(ctx);
+    Interceptor interceptor = builder.build();
+
+    Event event = EventBuilder.withBody("test", Charsets.UTF_8);
+    event.getHeaders().put(Constants.KEY_DEFAULT, "incumbent+value");
+
+    Assert.assertNotNull(event.getHeaders().get(Constants.KEY_DEFAULT));
+
+    event = interceptor.intercept(event);
+    String val = event.getHeaders().get(Constants.KEY_DEFAULT);
+
+    Assert.assertNotNull(val);
+    Assert.assertEquals("incumbent+value", val);
+  }
+}


### PR DESCRIPTION
/**
 * Interceptor class that join two or more headers to a new header of all events.
 *
 * Properties:<p>
 *   joinKeys: Headers to join together.
 *        (default is "key")<p>
 *
 *   joinKeyDefaultValues: default value to keys.
 *        (default is "NA")<p>
 *
 *   joinDelimiter: join delimiter.
 *        (default is "-")<p>
 *
 *   key: Key to use in join header insertion.
 *        (default is "key")<p>
 *
 *   preserveExisting: Whether to preserve an existing value for 'key'
 *                     (default is true)<p>
 *
 * Sample config:<p>
 *
 * <code>
 *   agent.sources.r1.channels = c1<p>
 *   agent.sources.r1.type = SEQ<p>
 *   agent.sources.r1.interceptors = i1<p>
 *   agent.sources.r1.interceptors.i1.type = join<p>
 *   agent.sources.r1.interceptors.i1.joinKeys = topic partition<p>
 *   agent.sources.r1.interceptors.i1.joinKeyDefaultValues = NA<p>
 *   agent.sources.r1.interceptors.i1.joinDelimiter = -<p>
 *   agent.sources.r1.interceptors.i1.preserveExisting = false<p>
 *   agent.sources.r1.interceptors.i1.key = datacenter<p>
 * </code>
 *
 */