### PR TITLE
merge modification of http source (#8)

### DIFF
--- a/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/channel/MemoryChannel.java
@@ -59,7 +59,8 @@ public class MemoryChannel extends BasicChannelSemantics {
   private static final Integer defaultByteCapacityBufferPercentage = 20;
 
   private static final Integer defaultKeepAlive = 3;
-
+  private static final Integer defaultPutTimeout = 10;
+  
   private class MemoryTransaction extends BasicTransactionSemantics {
     private LinkedBlockingDeque<Event> takeList;
     private LinkedBlockingDeque<Event> putList;

--- a/flume-ng-core/src/main/java/org/apache/flume/source/http/BLOBHandler.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/http/BLOBHandler.java
@@ -73,6 +73,11 @@ public class BLOBHandler implements HTTPSourceHandler {
       }
       headers.put(parameter, value);
     }
+    /*String charset = request.getCharacterEncoding();
+    headers.put("charset", charset);*/
+    
+    String servletPath = request.getServletPath();
+    headers.put("path", servletPath);
 
     for (String header : mandatoryHeaders) {
       Preconditions.checkArgument(headers.containsKey(header),

--- a/flume-ng-core/src/main/java/org/apache/flume/source/http/HTTPSource.java
+++ b/flume-ng-core/src/main/java/org/apache/flume/source/http/HTTPSource.java
@@ -287,6 +287,50 @@ public class HTTPSource extends AbstractSource implements
             throws IOException {
       doPost(request, response);
     }
+    @Override
+    public void doPut(HttpServletRequest request, HttpServletResponse response)
+            throws IOException {
+      List<Event> events = Collections.emptyList(); //create empty list
+      try {
+        events = handler.getEvents(request);
+      } catch (HTTPBadRequestException ex) {
+        LOG.warn("Received bad request from client. ", ex);
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                "Bad request from client. "
+                + ex.getMessage());
+        return;
+      } catch (Exception ex) {
+        LOG.warn("Deserializer threw unexpected exception. ", ex);
+        response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                "Deserializer threw unexpected exception. "
+                + ex.getMessage());
+        return;
+      }
+      sourceCounter.incrementAppendBatchReceivedCount();
+      sourceCounter.addToEventReceivedCount(events.size());
+      try {
+        getChannelProcessor().processEventBatch(events);
+      } catch (ChannelException ex) {
+        LOG.warn("Error appending event to channel. "
+                + "Channel might be full. Consider increasing the channel "
+                + "capacity or make sure the sinks perform faster.", ex);
+        response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE,
+                "Error appending event to channel. Channel might be full."
+                + ex.getMessage());
+        return;
+      } catch (Exception ex) {
+        LOG.warn("Unexpected error appending event to channel. ", ex);
+        response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+                "Unexpected error while appending event to channel. "
+                + ex.getMessage());
+        return;
+      }
+      response.setCharacterEncoding(request.getCharacterEncoding());
+      response.setStatus(HttpServletResponse.SC_CREATED);
+      response.flushBuffer();
+      sourceCounter.incrementAppendBatchAcceptedCount();
+      sourceCounter.addToEventAcceptedCount(events.size());
+    }
   }
 
   private static class HTTPSourceSocketConnector extends SslSocketConnector {

--- a/flume-ng-dist/src/main/assembly/bin.xml
+++ b/flume-ng-dist/src/main/assembly/bin.xml
@@ -59,7 +59,7 @@
   <fileSets>
     <fileSet>
       <directory>../</directory>
-
+      <lineEnding>unix</lineEnding>
       <excludes>
         <exclude>flume-ng-configuration/**</exclude>
         <exclude>flume-ng-sdk/**</exclude>


### PR DESCRIPTION
* http source添加处理PUT请求

* 添加repository，解决编译时无法下载jar问题

* http source处理put请求成功时返回的状态码由200改为201

* 修改http/BLOBHandler.java添加event header属性：charset和contextPath

* 1)解决编译时checkstyle问题；
2）jar包中添加源码；

* 1)修改不能出来put的bug；
2）打包文件换行符强制为unix格式

* memchannel增加超时配置选项

* fix complie error

* 去掉putTimeout

* 1）修改http source put成功时的返回值
2）hbase、hadoop升级为最新版本

* 修改http在的资源路径映射到event header的名字为path

# Conflicts:
#	flume-ng-core/src/test/java/org/apache/flume/interceptor/TestHeaderToBodyInterceptor.java
#	pom.xml